### PR TITLE
feat: 커리어넷 v1 진로심리검사 연동 추가

### DIFF
--- a/src/main/java/com/teameau/waymore/careernet/client/CareerNetClient.java
+++ b/src/main/java/com/teameau/waymore/careernet/client/CareerNetClient.java
@@ -1,0 +1,50 @@
+package com.teameau.waymore.careernet.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.Map;
+
+@Component
+public class CareerNetClient {
+    private final WebClient webClient;
+    private final String apiKey;
+
+    public CareerNetClient(
+            @Value("${CAREERNET_BASE_URL:https://www.career.go.kr}") String baseUrl,
+            @Value("${CAREERNET_API_KEY}") String apiKey
+    ) {
+        this.webClient = WebClient.builder().baseUrl(baseUrl).build();
+        this.apiKey = apiKey;
+    }
+
+    public JsonNode getQuestions(String qno) {
+        return webClient.get()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/inspct/openapi/test/questions")
+                        .queryParam("apikey", apiKey)
+                        .queryParam("q", qno)
+                        .build())
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .block();
+    }
+
+    public JsonNode createReport(Map<String, Object> payload) {
+        return webClient.post()
+                .uri("/inspct/openapi/test/report")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(withApiKey(payload, "apikey"))
+                .retrieve()
+                .bodyToMono(JsonNode.class)
+                .block();
+    }
+
+    private Map<String, Object> withApiKey(Map<String, Object> payload, String keyName) {
+        payload.put(keyName, apiKey);
+        return payload;
+    }
+}

--- a/src/main/java/com/teameau/waymore/careernet/controller/CareerNetController.java
+++ b/src/main/java/com/teameau/waymore/careernet/controller/CareerNetController.java
@@ -1,0 +1,47 @@
+package com.teameau.waymore.careernet.controller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.teameau.waymore.careernet.dto.CareerNetReportRequest;
+import com.teameau.waymore.careernet.dto.CareerNetTestResponse;
+import com.teameau.waymore.careernet.service.CareerNetService;
+import com.teameau.waymore.common.CommonResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "커리어넷 진로검사", description = "커리어넷 진로심리검사 연동 API")
+@RestController
+@RequestMapping("/api/careernet")
+@RequiredArgsConstructor
+public class CareerNetController {
+    private final CareerNetService careerNetService;
+
+    @GetMapping("/tests")
+    @Operation(summary = "검사목록조회", security = { @SecurityRequirement(name = "bearerAuth") })
+    public CommonResponseDto<List<CareerNetTestResponse>> getTests() {
+        return CommonResponseDto.success(careerNetService.getTests());
+    }
+
+    @GetMapping("/tests/questions")
+    @Operation(summary = "진로검사 문항 조회", security = { @SecurityRequirement(name = "bearerAuth") })
+    public CommonResponseDto<JsonNode> getQuestions(@RequestParam String qno) {
+        return CommonResponseDto.success(careerNetService.getQuestions(qno));
+    }
+
+    @GetMapping("/tests/{qno}/questions")
+    @Operation(summary = "진로검사 문항 조회", security = { @SecurityRequirement(name = "bearerAuth") })
+    public CommonResponseDto<JsonNode> getQuestionsByPath(@PathVariable String qno) {
+        return CommonResponseDto.success(careerNetService.getQuestions(qno));
+    }
+
+    @PostMapping("/reports")
+    @Operation(summary = "검사결과조회", security = { @SecurityRequirement(name = "bearerAuth") })
+    public CommonResponseDto<JsonNode> createReport(@Valid @RequestBody CareerNetReportRequest request) {
+        return CommonResponseDto.success(careerNetService.createReport(request));
+    }
+}

--- a/src/main/java/com/teameau/waymore/careernet/dto/CareerNetReportRequest.java
+++ b/src/main/java/com/teameau/waymore/careernet/dto/CareerNetReportRequest.java
@@ -1,0 +1,27 @@
+package com.teameau.waymore.careernet.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record CareerNetReportRequest(
+        @NotBlank(message = "심리검사번호는 필수입니다.")
+        String qno,
+
+        @NotBlank(message = "검사자 타입은 필수입니다.")
+        String trgetSe,
+
+        @NotBlank(message = "성별 코드는 필수입니다.")
+        String gender,
+
+        String school,
+
+        @NotBlank(message = "학년은 필수입니다.")
+        String grade,
+
+        @NotNull(message = "검사 시작일시는 필수입니다.")
+        Long startDtm,
+
+        @NotBlank(message = "답변은 필수입니다.")
+        String answers
+) {
+}

--- a/src/main/java/com/teameau/waymore/careernet/dto/CareerNetTestResponse.java
+++ b/src/main/java/com/teameau/waymore/careernet/dto/CareerNetTestResponse.java
@@ -1,0 +1,12 @@
+package com.teameau.waymore.careernet.dto;
+
+import java.util.List;
+
+public record CareerNetTestResponse(
+        String qno,
+        String name,
+        List<String> targetCodes,
+        String answerExample,
+        String note
+) {
+}

--- a/src/main/java/com/teameau/waymore/careernet/service/CareerNetService.java
+++ b/src/main/java/com/teameau/waymore/careernet/service/CareerNetService.java
@@ -1,0 +1,56 @@
+package com.teameau.waymore.careernet.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.teameau.waymore.careernet.client.CareerNetClient;
+import com.teameau.waymore.careernet.dto.CareerNetReportRequest;
+import com.teameau.waymore.careernet.dto.CareerNetTestResponse;
+import com.teameau.waymore.common.exception.BusinessException;
+import com.teameau.waymore.common.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class CareerNetService {
+    private final CareerNetClient careerNetClient;
+
+    public List<CareerNetTestResponse> getTests() {
+        return CareerNetTestCatalog.getTests();
+    }
+
+    public JsonNode getQuestions(String qno) {
+        JsonNode response = careerNetClient.getQuestions(qno);
+        ensureV1Success(response);
+        return response;
+    }
+
+    public JsonNode createReport(CareerNetReportRequest request) {
+        if (!StringUtils.hasText(request.answers())) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST);
+        }
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("qestrnSeq", request.qno());
+        payload.put("trgetSe", request.trgetSe());
+        payload.put("gender", request.gender());
+        payload.put("school", request.school());
+        payload.put("grade", request.grade());
+        payload.put("startDtm", request.startDtm());
+        payload.put("answers", request.answers());
+
+        JsonNode response = careerNetClient.createReport(payload);
+        ensureV1Success(response);
+        return response;
+    }
+
+    private void ensureV1Success(JsonNode response) {
+        if (response == null || !"Y".equals(response.path("SUCC_YN").asText())) {
+            throw new BusinessException(ErrorCode.INVALID_REQUEST);
+        }
+    }
+}

--- a/src/main/java/com/teameau/waymore/careernet/service/CareerNetTestCatalog.java
+++ b/src/main/java/com/teameau/waymore/careernet/service/CareerNetTestCatalog.java
@@ -1,0 +1,33 @@
+package com.teameau.waymore.careernet.service;
+
+import com.teameau.waymore.careernet.dto.CareerNetTestResponse;
+
+import java.util.List;
+
+final class CareerNetTestCatalog {
+    private CareerNetTestCatalog() {
+    }
+
+    static List<CareerNetTestResponse> getTests() {
+        return List.of(
+                new CareerNetTestResponse("30", "직업흥미검사(K) - 중학생", List.of("100206"), "1=3 2=2 3=2 ...", null),
+                new CareerNetTestResponse("31", "직업흥미검사(K) - 고등학생", List.of("100207"), "1=3 2=2 3=2 ...", null),
+                new CareerNetTestResponse("8", "진로개발준비도검사", List.of("100208", "100209", "100210", "100214", "100215"), "2,2,2,3,3,2,3,...", null),
+                new CareerNetTestResponse("9", "이공계전공적합도검사", List.of("100208", "100209", "100210", "100214", "100215"), "2,2,2,3,...", null),
+                new CareerNetTestResponse("10", "주요능력효능감검사", List.of("100208", "100209", "100210", "100214", "100215"), "2,2,2,3,...", null),
+                new CareerNetTestResponse("19", "진로흥미탐색 - 초등학생", List.of("100205"), "1=5 2=4 3=5 4=5 5=4 ...", null),
+                new CareerNetTestResponse("32", "진로개발역량 - 초등학생", List.of("100205"), "1=5 2=4 3=5 4=5 5=4 ...", null),
+                new CareerNetTestResponse("20", "직업적성검사 - 중학생", List.of("100206"), "1=5 2=4 3=5 4=5 5=4 ...", null),
+                new CareerNetTestResponse("21", "직업적성검사 - 고등학생", List.of("100207"), "1=5 2=4 3=5 4=5 5=4 ...", null),
+                new CareerNetTestResponse("35", "진로성숙도검사 - 중학생", List.of("100206"), "1=5 2=4 3=5 4=5 5=4 ... 13=1,8 ...", "13번 문항은 답 2개를 순서대로 입력하며, 답변 8(기타)은 주관식 답변이 필요합니다."),
+                new CareerNetTestResponse("36", "진로성숙도검사 - 고등학생", List.of("100207"), "1=5 2=4 3=5 4=5 5=4 ... 13=1,6 ...", "13번 문항은 답 2개를 순서대로 입력하며, 답변 9(기타)은 주관식 답변이 필요합니다."),
+                new CareerNetTestResponse("24", "직업가치관검사 - 중학생", List.of("100206"), "1=1 2=4 3=5 ...", null),
+                new CareerNetTestResponse("25", "직업가치관검사 - 고등학생", List.of("100207"), "1=1 2=4 3=5 ...", null),
+                new CareerNetTestResponse("6", "직업가치관검사 - 일반,대학생", List.of("100208", "100209", "100210", "100214", "100215"), "B1=1 B2=4 B3=5 ...", null),
+                new CareerNetTestResponse("26", "진로개발역량검사 - 중학생", List.of("100206"), "1=1 2=4 3=5 ...", null),
+                new CareerNetTestResponse("27", "진로개발역량검사 - 고등학생", List.of("100207"), "1=1 2=4 3=5 ...", null),
+                new CareerNetTestResponse("37", "진로실행력검사 - 중학생", List.of("100206"), "1=5 2=4 3=5 4=5 5=4 ...", null),
+                new CareerNetTestResponse("38", "진로실행력검사 - 고등학생", List.of("100207"), "1=5 2=4 3=5 4=5 5=4 ...", null)
+        );
+    }
+}


### PR DESCRIPTION
### Issue No
- #25 

### Description
  - 커리어넷 v1 문항 조회 API 연동
  - 커리어넷 v1 검사 결과 요청 API 연동
  - 공식 코드표 기반 검사 카탈로그 조회 추가

### Note
- 배포 서버에서 swagger 테스트 진행